### PR TITLE
Strip HTML from the actual README file that is packed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,9 @@ jobs:
       - name: Test
         run: dotnet test -c Release
       - name: Strip HTML from README
-        uses: d-edge/strip-markdown-html@v0.1
+        uses: d-edge/strip-markdown-html@v0.2
         with:
           input-path: README.md
-          output-path: $PROJECT_NAME/README.md
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
 <a href="https://github.com/d-edge/extLauncher/blob/main/LICENSE" title="license"><img src="https://img.shields.io/github/license/d-edge/extLauncher" alt="license" /></a>
 </p>
 
-<!--
-    <a href="https://www.nuget.org/packages/extLauncher/" title="nuget"><img src="https://img.shields.io/nuget/vpre/extLauncher" alt="version" /></a>
-    <a href="https://www.nuget.org/stats/packages/extLauncher?groupby=Version" title="stats"><img src="https://img.shields.io/nuget/dt/extLauncher" alt="download" /></a> -->
-
 <br />
 
 extLauncher is a dotnet tool to search and launch quickly projects in the user's preferred application. extLauncher is maintained by folks at [D-EDGE](https://www.d-edge.com/).


### PR DESCRIPTION
Fixes #19 

It seems that the bit of HTML that is commented out isn't stripped properly, there's a `\-->` that remains.